### PR TITLE
refactor: Remove resume upload field from Join Us form

### DIFF
--- a/join.html
+++ b/join.html
@@ -230,13 +230,6 @@
         </div>
       </div>
 
-      <!-- Resume Upload -->
-      <div class="form-group">
-        <label for="resume-file" data-en="Upload Resume (PDF, DOCX)" data-es="Subir CV (PDF, DOCX)">Upload Resume (PDF, DOCX)</label>
-        <input type="file" id="resume-file" name="resume_file" accept=".pdf,.doc,.docx">
-        <!-- Note: Actual file upload handling is done in JavaScript and requires server-side processing (e.g., pre-signed URLs) -->
-      </div>
-
 
       <!-- Submit Button -->
       <div class="form-group">


### PR DESCRIPTION
- Removed the entire 'Resume Upload' section (div.form-group containing input#resume-file) from the form in `join.html`.
- Verified that `contact.html` does not contain any file upload fields, so no changes were needed there.