### PR TITLE
fix: Ensure Font Awesome icons display correctly in FABs

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -197,6 +197,17 @@ header {
   background: var(--primary-dark);
 }
 
+/* Explicit styling for Font Awesome solid icons within FABs */
+.fab i.fas {
+  font-family: "Font Awesome 6 Free", "FontAwesome", sans-serif;
+  font-weight: 900; /* FAS (Solid) icons need font-weight 900 */
+  font-style: normal; /* Reset any inherited italicization */
+  /* display: inline-block; /* Usually handled by FA's CSS but can be explicit */
+  /* text-rendering: auto; /* Usually handled by FA's CSS */
+  /* -webkit-font-smoothing: antialiased; /* Usually handled by FA's CSS */
+  /* -moz-osx-font-smoothing: grayscale; /* Usually handled by FA's CSS */
+}
+
 /* FORM (shared by Contact & Join) */
 form {
   max-width: 560px;


### PR DESCRIPTION
- I verified the Font Awesome CSS link and FAB HTML structure are correct.
- I inspected existing CSS for .fab elements.
- I added explicit CSS rules for `.fab i.fas` in `css/global.css` to ensure proper `font-family`, `font-weight: 900`, and `font-style` are applied. This aims to resolve issues where icons might not be rendering due to style conflicts or insufficient specificity.